### PR TITLE
Update typeahead.js-bootstrap.css

### DIFF
--- a/typeahead.js-bootstrap.css
+++ b/typeahead.js-bootstrap.css
@@ -1,7 +1,12 @@
+.twitter-typeahead  { 
+width: 100%;
+}
+
 .twitter-typeahead .tt-query,
 .twitter-typeahead .tt-hint {
   margin-bottom: 0;
 }
+
 
 .tt-dropdown-menu {
   min-width: 160px;


### PR DESCRIPTION
set the width of the wrapping span to 100%, see: http://stackoverflow.com/questions/18167246/typeahead-problems-with-bootstrap-3-0-rc1/18171568
